### PR TITLE
Fix semantic versioning issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 `pterradactyl` adheres to [Semantic Versioning](http://semver.org/).
 
 #### 1.x Releases
-- `1.2.x` Releases - [1.2.7](#127) | [1.2.8](#128) | [1.2.10](#1210)
+- `1.2.x` Releases - [1.2.7](#127) | [1.2.8](#128) | [1.2.10](#1210) | [1.2.11](#1211) 
 
 ---
 ## Unreleased
@@ -18,6 +18,14 @@ All notable changes to this project will be documented in this file.
 #### Removed
 
 #### Fixed
+
+
+---
+## 1.2.11
+
+#### Fixed
+- Allow non-semantic versioning in the terraform provider plugin configuration.
+  - Fixed by [Marcin Zalewski](https://github.com/marcinjzalewski) in Pull Request [#6](https://github.com/Nike-Inc/pterradactyl/pull/6)
 
 ---
 ## 1.2.10

--- a/pterradactyl/terraform/terraform.py
+++ b/pterradactyl/terraform/terraform.py
@@ -173,7 +173,7 @@ class Terraform(object):
             repo=repo
         ), headers=self.auth_headers.get(domain)).json()
         for r in releases_res:
-            version = r.get('tag_name').split('v')[1]
+            version = r.get("tag_name")[1:] if r.get("tag_name").startswith("v") else r.get("tag_name")
             if Version(version) in spec and Version(version) > Version(latest_release[0]):
                 for a in r['assets']:
                     asset_url = a['browser_download_url']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pterradactyl"
-version = "1.2.10"
+version = "1.2.11"
 description = "hiera-inspired terraform wrapper"
 authors = ["Rob King <rob.king@nike.com>",
            "Vincent Liu <vincent.liu@nike.com>"


### PR DESCRIPTION
Fix semantic versioning issue.
Some tag names do not follow semantic versioning, and does not contain 'v' in the tag name.
We should fix the logic which gets version name from the tag name. Which sometimes does not contain 'v'.