### PR TITLE
Fixes shell command missing current context environment variables

### DIFF
--- a/pterradactyl/facter/shell.py
+++ b/pterradactyl/facter/shell.py
@@ -33,6 +33,7 @@ class ShellFacter(BaseFacter):
 
   def __run_fact(self, spec, facts):
     script = spec['command'] if type(spec) is dict else spec
+    # We are copying the facts into another variable so that we don't merge the env vars to the pterradactyl facts, but only use them for the subprocess call
     env_vars = facts.copy()
     return self.__postprocess(subprocess.run(script, shell=True, text=True, env=env_vars.update(os.environ), stdout=subprocess.PIPE).stdout.rstrip(), spec)
 

--- a/pterradactyl/facter/shell.py
+++ b/pterradactyl/facter/shell.py
@@ -1,6 +1,7 @@
 import subprocess
 import json
 import jsonpath_ng
+import os
 
 from .base import BaseFacter
 
@@ -32,7 +33,8 @@ class ShellFacter(BaseFacter):
 
   def __run_fact(self, spec, facts):
     script = spec['command'] if type(spec) is dict else spec
-    return self.__postprocess(subprocess.run(script, shell=True, text=True, env=facts, stdout=subprocess.PIPE).stdout.rstrip(), spec)
+    env_vars = facts.copy()
+    return self.__postprocess(subprocess.run(script, shell=True, text=True, env=env_vars.update(os.environ), stdout=subprocess.PIPE).stdout.rstrip(), spec)
 
   def facts(self, facts={}):
     return {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pterradactyl"
-version = "1.2.11"
+version = "1.2.12"
 description = "hiera-inspired terraform wrapper"
 authors = ["Rob King <rob.king@nike.com>",
            "Vincent Liu <vincent.liu@nike.com>"
@@ -22,6 +22,7 @@ python = "^3.7 || ^3.8"
 python-interface = "^1.5.3"
 pyyaml = "^5.3.1"
 jinja2 = "^2.11.1"
+MarkupSafe = "2.0.1"
 appdirs = "^1.4.3"
 jsonpath-ng = "^1.5.1"
 semantic_version = "^2.8.4"

--- a/tests/pterradactyl/facter/test_shell.py
+++ b/tests/pterradactyl/facter/test_shell.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 import pterradactyl.facter.shell as shell
 
 
@@ -36,3 +37,21 @@ class TestFacterShellCommands(unittest.TestCase):
         output_facts = shell.ShellFacter(shell_facter_data).facts()
         assert output_facts.get('single_command') == "single_command"
         assert output_facts.get('json_parse_command_output') == "world1"
+
+    def test_check_context_env_vars(self):
+        os.environ['TEST_ENV'] = 'test'
+        shell_facter_data = {
+            'single_command': 'echo \'single_command\'',
+            'json_parse_command_output': {
+                'command': 'echo \'{"hello":["world1", "world2"] }\'',
+                'jsonpath': '$.hello[0]',
+                'data_json': '{"hello":["world1", "world2"] }'
+            },
+            'json_env_vars_output': {
+                'command': 'env'
+            }
+        }
+        output_facts = shell.ShellFacter(shell_facter_data).facts()
+        assert output_facts.get('single_command') == "single_command"
+        assert output_facts.get('json_parse_command_output') == "world1"
+        assert 'TEST_ENV=test' in output_facts.get('json_env_vars_output')


### PR DESCRIPTION
Updated shell command to include the run environment variables
Fixes dependency which was causing the pterradactyl command to break if not forced to a downgraded version