### PR TITLE
Allow to use github repo as module_path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pterradactyl"
-version = "1.2.13"
+version = "1.3.0"
 description = "hiera-inspired terraform wrapper"
 authors = ["Rob King <rob.king@nike.com>",
            "Vincent Liu <vincent.liu@nike.com>"


### PR DESCRIPTION
Currently pterradactyl uses terrafoirm modules that are locates in local folder. 
This PR allows to specify a github monorepo which keeps modules and being cloned at tf init stage.