### PR TITLE
Module reference to manifest

### DIFF
--- a/pterradactyl/terraform/config.py
+++ b/pterradactyl/terraform/config.py
@@ -40,12 +40,12 @@ class TerraformConfig(object):
         self.cwd = cwd
         self.terraform_config = config.get('terraform')
         self.module_path = lookup(self.terraform_config, 'module_path', default=[])
-        self.module_ref = lookup(self.terraform_config, 'module_ref', default="master")
         self.root_dir = config.dir
         context = {**facts, **{'facts': facts}}
         self.hiera = phiera.Hiera(config.get('hiera'), context=context, base_path=config.dir)
 
-        manifest = self.hiera.get('manifest', {'modules': []}, merge=dict, merge_deep=True)
+        manifest = self.hiera.get('manifest', {'version': '', 'modules': []}, merge=dict, merge_deep=True)
+        self.module_ref = manifest['version']
         self.modules = self.alias_modules(manifest['modules'])
 
     def alias_modules(self, modules):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pterradactyl"
-version = "1.2.13"
+version = "1.3.0"
 description = "hiera-inspired terraform wrapper"
 authors = ["Rob King <rob.king@nike.com>",
            "Vincent Liu <vincent.liu@nike.com>"


### PR DESCRIPTION
Added possibility to specify terraform modules version to be cloned for a deployment in a manifest:
> manifest:
>   version: cf1ac826168e546453f0b5a45f57f5294b2b5cc1
>   modules:
>     - s3
>     - vpc
>     - eks_cluster
