### PR TITLE
Fix redundant tf inits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ All notable changes to this project will be documented in this file.
 
 
 ---
+## 1.6.1
+
+#### Fixed
+- Fixed redundant terraform init on every command - Issue #26
+
+---
 ## 1.6.0
 
 #### Fixed

--- a/pterradactyl/terraform/terraform.py
+++ b/pterradactyl/terraform/terraform.py
@@ -100,6 +100,8 @@ class Terraform(object):
             state = json.load(f)
 
         for path in glob.iglob(os.path.join(self.cwd, '*.tf.json')):
+            if os.path.basename(path) == 'variables.tf.json':
+                continue
             with open(path) as f:
                 tf = json.load(f)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pterradactyl"
-version = "1.6.0"
+version = "1.6.1"
 description = "hiera-inspired terraform wrapper"
 authors = [
     "Rob King <rob.king@nike.com>",

--- a/tests/pterradactyl/terraform/test_backend_validation.py
+++ b/tests/pterradactyl/terraform/test_backend_validation.py
@@ -1,0 +1,128 @@
+import json
+import os
+import shutil
+import tempfile
+from unittest import TestCase
+from unittest.mock import PropertyMock, patch
+
+from pterradactyl.terraform.terraform import Terraform
+
+
+class TestTerraformBackendValidation(TestCase):
+
+    def setUp(self):
+        self.workspace = tempfile.mkdtemp()
+        os.makedirs(os.path.join(self.workspace, '.terraform'), exist_ok=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.workspace)
+
+    def _write_state(self, backend_type='s3', bucket='example-bucket', key='example.tfstate'):
+        state = {
+            "backend": {
+                "type": backend_type,
+                "config": {
+                    "bucket": bucket,
+                    "key": key,
+                    "region": "us-west-2"
+                }
+            }
+        }
+        with open(os.path.join(self.workspace, '.terraform', 'terraform.tfstate'), 'w') as state_file:
+            json.dump(state, state_file)
+
+    def _write_main_tf(self, backend_type='s3', bucket='example-bucket', key='example.tfstate'):
+        main_tf = {
+            "terraform": {
+                "backend": {
+                    backend_type: {
+                        "bucket": bucket,
+                        "key": key,
+                        "region": "us-west-2"
+                    }
+                }
+            }
+        }
+        with open(os.path.join(self.workspace, 'main.tf.json'), 'w') as main_file:
+            json.dump(main_tf, main_file)
+
+    def _write_variables_tf(self):
+        variables_tf = {
+            "variable": {
+                "dummy": {
+                    "type": "string"
+                }
+            }
+        }
+        with open(os.path.join(self.workspace, 'variables.tf.json'), 'w') as variables_file:
+            json.dump(variables_tf, variables_file)
+
+    def _create_terraform(self, mock_config, env_vars=None):
+        mock_config.return_value.get.return_value = {
+            'version': '1.0.0',
+            'plugins': []
+        }
+        mock_config.return_value.cache_dir = self.workspace
+        return Terraform(cwd=self.workspace, env_vars=env_vars or {})
+
+    def _exercise_backend_validation(self, mock_config, *, state_bucket, main_bucket, include_variables):
+        self._write_state(backend_type='s3', bucket=state_bucket)
+        self._write_main_tf(backend_type='s3', bucket=main_bucket)
+
+        if include_variables:
+            self._write_variables_tf()
+
+        terraform = self._create_terraform(mock_config)
+        with patch.object(type(terraform), 'terraform', new_callable=PropertyMock) as mock_tf_bin, \
+             patch.object(terraform, 'execute') as mock_execute, \
+             patch.object(terraform, '_Terraform__do_validate', return_value={'valid': True}):
+            mock_tf_bin.return_value = '/mock/terraform'
+            result = terraform.validate()
+
+        self.assertTrue(result)
+        return mock_execute
+
+    @patch('pterradactyl.terraform.terraform.Config')
+    def test_backend_requires_init_with_variables_file(self, mock_config):
+        execute = self._exercise_backend_validation(
+            mock_config,
+            state_bucket='bucket-a',
+            main_bucket='bucket-b',
+            include_variables=True,
+        )
+
+        execute.assert_called_once_with('init')
+
+    @patch('pterradactyl.terraform.terraform.Config')
+    def test_backend_ok_with_variables_file(self, mock_config):
+        execute = self._exercise_backend_validation(
+            mock_config,
+            state_bucket='bucket-a',
+            main_bucket='bucket-a',
+            include_variables=True,
+        )
+
+        execute.assert_not_called()
+
+    @patch('pterradactyl.terraform.terraform.Config')
+    def test_backend_requires_init_without_variables_file(self, mock_config):
+        execute = self._exercise_backend_validation(
+            mock_config,
+            state_bucket='bucket-a',
+            main_bucket='bucket-b',
+            include_variables=False,
+        )
+
+        execute.assert_called_once_with('init')
+
+    @patch('pterradactyl.terraform.terraform.Config')
+    def test_backend_ok_without_variables_file(self, mock_config):
+        execute = self._exercise_backend_validation(
+            mock_config,
+            state_bucket='bucket-a',
+            main_bucket='bucket-a',
+            include_variables=False,
+        )
+
+        execute.assert_not_called()
+


### PR DESCRIPTION
The `_validate_backend()` method was looking for `terraform.backend` in any gathered file of the form `*.tf.json`
The newly added file `variables.tf.json` from version 1.6.0 will never have this field. To avoid triggering `tf init` again, we skip this file so that it is not treated like an error when the validate method sees this file.

Fixes [issue 26](https://github.com/Nike-Inc/pterradactyl/issues/26)